### PR TITLE
resolve #3 - add search box to MainActivity

### DIFF
--- a/app/src/main/java/com/example/android/liveupdates/MainActivity.java
+++ b/app/src/main/java/com/example/android/liveupdates/MainActivity.java
@@ -5,12 +5,19 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 
 public class MainActivity extends AppCompatActivity {
+
+    private EditText searchBoxEditText;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        searchBoxEditText = findViewById(R.id.main_search);
+
         Button topicBtn = findViewById(R.id.topicButton);
         Button genr = findViewById(R.id.genreButton);
 
@@ -18,7 +25,9 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onClick(View view) {
+                String githubQuery = searchBoxEditText.getText().toString();
                 Intent toTopicActivity = new Intent(MainActivity.this, TopicActivity.class);
+                toTopicActivity.putExtra("query", githubQuery);
                 startActivity(toTopicActivity);
             }
         });
@@ -26,7 +35,9 @@ public class MainActivity extends AppCompatActivity {
         genr.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                String githubQuery = searchBoxEditText.getText().toString();
                 Intent toTTopicActivity = new Intent(MainActivity.this, NewMainActivity.class);
+                toTTopicActivity.putExtra("query", githubQuery);
                 startActivity(toTTopicActivity);
             }
         });

--- a/app/src/main/java/com/example/android/liveupdates/NewMainActivity.java
+++ b/app/src/main/java/com/example/android/liveupdates/NewMainActivity.java
@@ -17,12 +17,14 @@ package com.example.android.liveupdates;
 
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
 
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.AsyncTaskLoader;
 import androidx.loader.content.Loader;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.View;
@@ -58,6 +60,8 @@ public class NewMainActivity extends AppCompatActivity implements
 
     private ProgressBar mLoadingIndicator;
 
+    private Button sBtn;
+
     private Context context;
 
     @Override
@@ -65,12 +69,33 @@ public class NewMainActivity extends AppCompatActivity implements
         super.onCreate(savedInstanceState);
         setContentView(R.layout.newactivity_main);
 
+        Intent intent = getIntent();
+        String queryMessage = intent.getStringExtra("query");
+
         mSearchBoxEditText = findViewById(R.id.et_search_box);
 
         mUrlDisplayTextView = findViewById(R.id.tv_url_display);
+        mSearchBoxEditText.setText(queryMessage);
+
         mSearchResultsTextView = findViewById(R.id.tv_github_search_results_json);
 
         sBtn= findViewById(R.id.searchbtn);
+
+        //Default search query from main activity
+        URL githubSearchUrl = NetworkUtils.buildUrl(queryMessage);
+        mUrlDisplayTextView.setText(githubSearchUrl.toString());
+
+        Bundle queryBundle = new Bundle();
+        queryBundle.putString(SEARCH_QUERY_URL_EXTRA, githubSearchUrl.toString());
+
+        LoaderManager loaderManager = getSupportLoaderManager();
+        Loader<String> githubSearchLoader = loaderManager.getLoader(GITHUB_SEARCH_LOADER);
+
+        if (githubSearchLoader == null) {
+            loaderManager.initLoader(GITHUB_SEARCH_LOADER, queryBundle, this);
+        } else {
+            loaderManager.restartLoader(GITHUB_SEARCH_LOADER, queryBundle, this);
+        } //end main query
 
         mErrorMessageDisplay = findViewById(R.id.tv_error_message_display);
         sBtn.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/example/android/liveupdates/TopicActivity.java
+++ b/app/src/main/java/com/example/android/liveupdates/TopicActivity.java
@@ -6,6 +6,11 @@ import androidx.annotation.Nullable;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.AsyncTaskLoader;
 import androidx.loader.content.Loader;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
@@ -47,6 +52,9 @@ public class TopicActivity extends AppCompatActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_topic);
+
+        Intent intent = getIntent();
+        String queryMessage = intent.getStringExtra("query");
         //mList=(RecyclerView)findViewById(R.id.ViewR);
         //  LinearLayoutManager layoutManager=new LinearLayoutManager(this);
         //mList.setLayoutManager(layoutManager);
@@ -54,6 +62,7 @@ public class TopicActivity extends AppCompatActivity implements
         //  mAdapter=new NewsAdapter(number_of_items);
         // mList.setAdapter(mAdapter);
         mSearchBoxEditText = findViewById(R.id.editT);
+        mSearchBoxEditText.setText(queryMessage);
         // ii=(ImageView)findViewById(R.id.i);
         mLoadingIndicator = findViewById(R.id.pb_loading_indicator);
         mSearchResultsTextView = findViewById(R.id.Res);
@@ -62,6 +71,22 @@ public class TopicActivity extends AppCompatActivity implements
         Button searchBtn = findViewById(R.id.searchbtn);
 
         context = this;
+
+        //Default search query from main activity
+        URL githubSearchUrl = NetworkUtils.buildUrl(queryMessage);
+        mUrlDisplayTextView.setText(githubSearchUrl.toString());
+
+        Bundle queryBundle = new Bundle();
+        queryBundle.putString(SEARCH_QUERY_URL_EXTRA, githubSearchUrl.toString());
+
+        LoaderManager loaderManager = getSupportLoaderManager();
+        Loader<String> githubSearchLoader = loaderManager.getLoader(LOADER);
+
+        if (githubSearchLoader == null) {
+            loaderManager.initLoader(LOADER, queryBundle, this);
+        } else {
+            loaderManager.restartLoader(LOADER, queryBundle, this);
+        } //end default query
 
         searchBtn.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,21 @@
     android:background="@drawable/background"
     tools:context=".MainActivity">
 
+
+    <EditText
+        android:id="@+id/main_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="21sp"
+        android:padding="10dp"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:hint="Search by Topic or Genre"
+        android:background="@color/white"
+        app:layout_constraintBottom_toTopOf="@id/genreButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
     <Button
         android:id="@+id/genreButton"
         android:layout_width="wrap_content"


### PR DESCRIPTION
I added the functionality for the search box on the main activity, but I left the styling fairly basic if you want to open a separate issue to address preferred styling.

I current left the separate search boxes on the query pages for an easier time making continued searches instead of going back and forth between activities, but if you like I can remove these if you want search box only on the First activity. 